### PR TITLE
remove byte order mark from _locales files to fix loading

### DIFF
--- a/_locales/da/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/da/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Giv spiller stikling",
   "hoc2020.agentClimb": "Agent flyt op",
   "hoc2020.flipLever": "Agent interager fremad",

--- a/_locales/da/hoc2020-ts-strings.json
+++ b/_locales/da/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "acceptér gave",
   "hoc2020.agentClimb|block": "agent kravl %n op",
   "hoc2020.flipLever|block": "træk i håndtag",

--- a/_locales/es-MX/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/es-MX/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Dar retoño al jugador",
   "hoc2020.agentClimb": "Agent subir",
   "hoc2020.flipLever": "Agent interactuar adelante",

--- a/_locales/es-MX/hoc2020-ts-strings.json
+++ b/_locales/es-MX/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "aceptar regalo",
   "hoc2020.agentClimb|block": "agent %n escalar",
   "hoc2020.flipLever|block": "activar palanca",

--- a/_locales/fr-CA/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/fr-CA/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Donner pousse d'arbre au joueur",
   "hoc2020.agentClimb": "Agent monte",
   "hoc2020.flipLever": "Agent interagit devant lui",

--- a/_locales/fr-CA/hoc2020-ts-strings.json
+++ b/_locales/fr-CA/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "accepter cadeau",
   "hoc2020.agentClimb|block": "agent grimpe de %n",
   "hoc2020.flipLever|block": "activer levier",

--- a/_locales/it/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/it/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Regala un arboscello al giocatore",
   "hoc2020.agentClimb": "L'Agent si sposta in alto",
   "hoc2020.flipLever": "L'Agent interagisce in avanti",

--- a/_locales/it/hoc2020-ts-strings.json
+++ b/_locales/it/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "accetta regalo",
   "hoc2020.agentClimb|block": "agent sale %n in cima",
   "hoc2020.flipLever|block": "attiva leva",

--- a/_locales/ja/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/ja/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "プレイヤーに苗木を贈る",
   "hoc2020.agentClimb": "Agent 登る",
   "hoc2020.flipLever": "Agent 前方とインタラクト",

--- a/_locales/ja/hoc2020-ts-strings.json
+++ b/_locales/ja/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "ギフトを受け取る",
   "hoc2020.agentClimb|block": "agent %n 登る",
   "hoc2020.flipLever|block": "レバーを動かす",

--- a/_locales/ko/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/ko/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "플레이어에게 묘목 주기",
   "hoc2020.agentClimb": "Agent 위로 이동하기",
   "hoc2020.flipLever": "Agent 앞쪽 상호 작용",

--- a/_locales/ko/hoc2020-ts-strings.json
+++ b/_locales/ko/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "선물 수락",
   "hoc2020.agentClimb|block": "Agent 위로 %n 이동",
   "hoc2020.flipLever|block": "손잡이 전환",

--- a/_locales/nb/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/nb/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Gi spiller ungtreet",
   "hoc2020.agentClimb": "Agent flytt opp",
   "hoc2020.flipLever": "Agent samhandle fremover",

--- a/_locales/nb/hoc2020-ts-strings.json
+++ b/_locales/nb/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "ta imot gave",
   "hoc2020.agentClimb|block": "agent klatre %n opp",
   "hoc2020.flipLever|block": "manipuler spak",

--- a/_locales/nl/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/nl/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Geef speler jong boompje",
   "hoc2020.agentClimb": "Agent beweegt omhoog",
   "hoc2020.flipLever": "Agent gebruikt voorliggende",

--- a/_locales/nl/hoc2020-ts-strings.json
+++ b/_locales/nl/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "cadeau accepteren",
   "hoc2020.agentClimb|block": "agent klimt %n omhoog",
   "hoc2020.flipLever|block": "hendel omdraaien",

--- a/_locales/pt-BR/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/pt-BR/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Entregar muda ao jogador",
   "hoc2020.agentClimb": "Mover Agent para cima",
   "hoc2020.flipLever": "Interagir para a frente com o Agent",

--- a/_locales/pt-BR/hoc2020-ts-strings.json
+++ b/_locales/pt-BR/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "aceitar presente",
   "hoc2020.agentClimb|block": "escalar %n com o Agent",
   "hoc2020.flipLever|block": "virar alavanca",

--- a/_locales/sv-SE/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/sv-SE/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Ge spelaren en trädplanta",
   "hoc2020.agentClimb": "Flytta agenten uppåt",
   "hoc2020.flipLever": "Låt agenten interagera framåt",

--- a/_locales/sv-SE/hoc2020-ts-strings.json
+++ b/_locales/sv-SE/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "ta emot gåva",
   "hoc2020.agentClimb|block": "låt agenten klättra %n steg uppåt",
   "hoc2020.flipLever|block": "växla spak",

--- a/_locales/tr/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/tr/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "Oyuncuya fidan ver",
   "hoc2020.agentClimb": "Agent yukarı taşı",
   "hoc2020.flipLever": "Agent ileri etkileşim",

--- a/_locales/tr/hoc2020-ts-strings.json
+++ b/_locales/tr/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "hediye kabul et",
   "hoc2020.agentClimb|block": "agent %n yukarı tırman",
   "hoc2020.flipLever|block": "şalteri aç kapat",

--- a/_locales/zh-CN/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/zh-CN/hoc2020-ts-jsdoc-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift": "给玩家送树苗",
   "hoc2020.agentClimb": "代理机器人向上移动",
   "hoc2020.flipLever": "代理机器人向前互动",

--- a/_locales/zh-CN/hoc2020-ts-strings.json
+++ b/_locales/zh-CN/hoc2020-ts-strings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "hoc2020.acceptGift|block": "接受礼物",
   "hoc2020.agentClimb|block": "代理机器人向上移动 %n",
   "hoc2020.flipLever|block": "开启拉杆",


### PR DESCRIPTION
fix encoding of the _locales files so you can load extension; they were UTF-8 + BOM for some reason, which is not recommended https://stackoverflow.com/a/2223926

You might need to clear the delete the extension locally and redownload it, from the video I got it looked like you got into a weird state -- you can do that like this:

![how-to-delete-project](https://user-images.githubusercontent.com/5615930/99615220-dac14380-29cf-11eb-8b2f-0b45af1ea333.gif)

If you want to confirm it will load before merging, just try importing https://github.com/jwunderl/hoc2020-ts