### PR TITLE
Add block strings for Slovak (sk)

### DIFF
--- a/_locales/sk/hoc2020-ts-jsdoc-strings.json
+++ b/_locales/sk/hoc2020-ts-jsdoc-strings.json
@@ -1,0 +1,13 @@
+{
+  "hoc2020.acceptGift": "Dá hráčovi sadenicu stromčeka",
+  "hoc2020.agentClimb": "Agent sa posúva nahor",
+  "hoc2020.flipLever": "Agent vykoná akciu pred sebou",
+  "hoc2020.leadRavager": "Naveďte ničitela",
+  "hoc2020.moveAgent": "Pohne agentom",
+  "hoc2020.placeFence": "Agent umiestni železné tyče",
+  "hoc2020.placePlanks": "Agent umiestni drevené dosky",
+  "hoc2020.placeRails": "Agent pod seba umiestni koľajnice",
+  "hoc2020.tillSoil": "Agent obrába pôdu",
+  "hoc2020.turnAgent": "Otočí agenta",
+  "hoc2020Different.customRepeatLoop": "Opakuj kód určený počet krát"
+}

--- a/_locales/sk/hoc2020-ts-strings.json
+++ b/_locales/sk/hoc2020-ts-strings.json
@@ -1,0 +1,17 @@
+{
+  "hoc2020.acceptGift|block": "prijať darček",
+  "hoc2020.agentClimb|block": "agent šplhaj o %n nahor",
+  "hoc2020.flipLever|block": "potiahni páčku",
+  "hoc2020.leadRavager|block": "naveď ničiteľa o %n dopredu",
+  "hoc2020.moveAgent|block": "agent pohni sa %d o %n",
+  "hoc2020.placeFence|block": "polož železné tyče pod seba",
+  "hoc2020.placePlanks|block": "polož dosku a posuň sa o %n vopred",
+  "hoc2020.placeRails|block": "umiestni koľajnice",
+  "hoc2020.tillSoil|block": "kultivovať pôdu a posunúť sa o %n vpred",
+  "hoc2020.turnAgent|block": "agent otoč sa %t",
+  "hoc2020Different.customRepeatLoop|block": "opakuj $n krát",
+  "hoc2020Different|block": "Obsah Hodiny kódu 2020",
+  "hoc2020|block": "Hodina kódu 2020",
+  "{id:category}Hoc2020": "Hodina kódu 2020",
+  "{id:category}Hoc2020Different": "Hoc2020Different"
+}

--- a/pxt.json
+++ b/pxt.json
@@ -29,6 +29,8 @@
         "_locales/nl/hoc2020-ts-strings.json",
         "_locales/pt-BR/hoc2020-ts-jsdoc-strings.json",
         "_locales/pt-BR/hoc2020-ts-strings.json",
+        "_locales/sk/hoc2020-ts-jsdoc-strings.json",
+        "_locales/sk/hoc2020-ts-strings.json",
         "_locales/sv-SE/hoc2020-ts-jsdoc-strings.json",
         "_locales/sv-SE/hoc2020-ts-strings.json",
         "_locales/tr/hoc2020-ts-jsdoc-strings.json",


### PR DESCRIPTION
Slovak block strings added to `_locales`.

@neonerz - This should work without a version update.